### PR TITLE
Cleanup + 404 + now

### DIFF
--- a/src/_assets/main.css
+++ b/src/_assets/main.css
@@ -18,6 +18,7 @@
   --font-mono: ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono",
     "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro",
     "Fira Mono", "Droid Sans Mono", "Courier New", monospace;
+  --font-serif-heading: "Source Serif VF", "Source Serif VF-Fallback-Bold", Georgia, serif;
   --font-w-bold: 800;
   --max-width: 36rem;
 
@@ -56,7 +57,12 @@
 
 @font-face {
   font-family:"Source Serif VF-Fallback";
-  size-adjust: 95%;
+  size-adjust: 105.5%;
+  src: local("Georgia");
+}
+@font-face {
+  font-family:"Source Serif VF-Fallback-Bold";
+  size-adjust: 97.5%;
   src: local("Georgia");
 }
 
@@ -195,11 +201,6 @@ ol {
   --flow-space: 0.5em;
 }
 
-article {
-  max-width: 60ch;
-  margin-inline: auto;
-}
-
 blockquote {
   max-width: 50ch;
   border-left: 0.5rem solid var(--color-primary);
@@ -319,7 +320,7 @@ pre code {
   font-size: var(--step-2);
 }
 .intro h2 {
-  font-family: var(--font-serif);
+  font-family: var(--font-serif-heading);
   font-size: var(--step-4);
   margin-top: 0;
 }
@@ -368,7 +369,7 @@ pre code {
   }
   & a h3 {
     font-size: var(--step-1);
-    font-family: var(--font-serif);
+    font-family: var(--font-serif-heading);
     text-decoration: none;
     position: relative;
     overflow: hidden;
@@ -442,11 +443,13 @@ footer .wa {
 /* Article page */
 
 article {
+  max-width: 800px;
+  margin-inline: auto;
   padding: 6rem 0;
   font-family: var(--font-serif);
   font-size: var(--step-1);
   & h1 {
-    font-family: var(--font-serif);
+    font-family: var(--font-serif-heading);
     text-align: center;
     margin-bottom: 4rem;
     font-weight: 600;

--- a/src/_assets/wa.js
+++ b/src/_assets/wa.js
@@ -260,9 +260,9 @@ function setUp(
   keyframes.forEach((keyframe, idx) => {
     circles.push([]);
     for (var j = 1; j < keyframe.length; j++) {
-      for (var i = 0; i <= 100; i++) {
+      for (var i = 0; i <= 120; i++) {
         // create a frame that takes the last blob, the current blob, and a timing function to tween the gap
-        let frame = lerpNodes(keyframe[j - 1], keyframe[j], ease(i / 100));
+        let frame = lerpNodes(keyframe[j - 1], keyframe[j], ease(i / 120));
         circles[idx].push(frame);
       }
     }
@@ -300,7 +300,7 @@ function draw(circles, canvas) {
   circles.forEach((circleFrames) => {
     let nodes = circleFrames.shift();
 
-    const circle = createBlob({ nodes }).render(ctx);
+    createBlob({ nodes }).render(ctx);
     circleFrames.push(nodes);
   });
   if (window) {
@@ -312,6 +312,6 @@ function draw(circles, canvas) {
 (() => {
   const canvases = document.querySelectorAll(".wa");
   canvases.forEach((canvas) => {
-    setUp(canvas, {});
+    setUp(canvas, { frames: 10, easing: "sinusoidal" });
   });
 })();

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -20,7 +20,6 @@
     {% else %}
     <link rel="canonical" href="{{config.url}}{{page.url}}">
     {% endif %}
-    {# <meta property="og:image" content="{{config.url}}/assets/og/{{og}}"/> #}
     <meta property="og:image" content="{{config.url}}{{page.url}}{{ title | ogImage }}"/>
     <meta property="og:title" content="{{title}}" />
     <meta property="og:url" content="{{config.url}}{{page.url}}" />
@@ -36,12 +35,9 @@
           {{ m() }}
         </a>
         <ul>
-          <li>
-            <a href="/articles/">Articles</a>
-          </li>
-          <li>
-            <a href="/hire/" class="active">Hire me</a>
-          </li>
+          <li><a href="/articles/">Articles</a></li>
+          <li><a href="/now/">Now</a></li>
+          <li><a href="/hire/" class="active">Hire me</a></li>
         </ul>
       </div>
       <main>

--- a/src/articles/2013-03-29-initial-impressions-of-jekyll.md
+++ b/src/articles/2013-03-29-initial-impressions-of-jekyll.md
@@ -3,7 +3,6 @@ date: "2013-03-29"
 description: "A handful of problems & a few solid upsides to the static site generator"
 title: "Initial impressions of Jekyll"
 permalink: /initial-impressions-of-jekyll/
-og: "initial-impressions-of-jekyll.jpg"
 # categories: ['development']
 ---
 

--- a/src/articles/2013-05-09-scroll-aware-header.md
+++ b/src/articles/2013-05-09-scroll-aware-header.md
@@ -5,7 +5,6 @@ description: One technique for designing a scroll-dependent hidden navigation ba
 title: Creating a Scroll Dependent Navigation
 permalink: /scroll-aware-header/
 categories: ['development']
-og: "scroll-aware-header-jpg"
 ---
 
   >This article was first published in 2013 and the information may be out of date

--- a/src/articles/2019-04-03-classroom-probot.md
+++ b/src/articles/2019-04-03-classroom-probot.md
@@ -3,7 +3,6 @@ permalink: '/classroom-probot/'
 date: '2019-04-03'
 title: 'Powering up GitHub Classroom with Probot'
 description: 'Automate low-hanging feedback and default settings'
-og: "classroom-probot-jpg"
 ---
 
   >This article was first published in 2019 and the information may be out of date.

--- a/src/articles/automatic-retries-with-fetch.md
+++ b/src/articles/automatic-retries-with-fetch.md
@@ -4,7 +4,6 @@ date: '2019-06-13'
 title: 'Adding Automatic Retries to Fetch'
 categories: ['javascript']
 description: How to add automatic retries to fetch without any libraries.
-og: "automatic-retries-with-fetch.jpg"
 ---
 
   >This article was first published in 2019. Many of the concepts still apply, and support for Fetch is widespread.

--- a/src/articles/bearer-cli-case-study.md
+++ b/src/articles/bearer-cli-case-study.md
@@ -4,6 +4,7 @@ tags: ['article', 'case study']
 permalink: /bearer-cli-case-study/
 description: 'A case study on launching the Bearer CLI docs'
 og: "bearer-cli-case-study.jpg"
+date: "2023-11-28"
 ---
 
 At [Bearer](https://bearer.com), one of my final projects as a technical content manager with the company involved the documentation for their open source project, Bearer CLI. I acted as the primary technical writer, technical editor, and documentation architect.

--- a/src/articles/custom-footnotes-mdx-gatsby.md
+++ b/src/articles/custom-footnotes-mdx-gatsby.md
@@ -3,7 +3,6 @@ permalink: '/advanced-custom-mdx-components/'
 date: '2019-05-15'
 title: 'Custom Footnotes with MDX in Gatsby'
 description: 'Using the MDX wrapper key to customize your MDX output'
-og: "custom-footnotes-mdx-gatsby.jpg"
 ---
 
   >This article was first published in 2019 and this site no longer runs on Gatsby.

--- a/src/articles/custom-horizontal-rule-markdown.md
+++ b/src/articles/custom-horizontal-rule-markdown.md
@@ -3,7 +3,7 @@ title: 'Custom horizontal rules with markdown-it and Eleventy'
 description: "By overriding markdown-it's default rendering, we can replace the horizontal rule with any element"
 permalink: /custom-hr-markdown/
 tags: ['11ty']
-og: "custom-horizontal-rule-markdown.jpg"
+date: "2023-11-28"
 ---
 
 When I migrated this site over from Gatsby, MDX, and React to [Eleventy](https://11ty.dev) and markdown I needed solutions for my [custom MDX components](/advanced-custom-mdx-components/). One that I wasn't expecting to pose a problem was my `.fancy` horizontal rule.

--- a/src/articles/docker-compose-postgresql.md
+++ b/src/articles/docker-compose-postgresql.md
@@ -2,7 +2,7 @@
 title: Quickly set up local PostgreSQL with Docker Compose
 description: Set up postgres and adminer locally with docker compose.
 permalink: /docker-compose-postgresql/
-og: "docker-compose-postgresql.jpg"
+date: "2024-05-11"
 ---
 
 [Docker Compose](https://docs.docker.com/compose/) is the fastest way to run a PostgreSQL server locally—even if you've never touched docker before. In fact, Docker Compose is a light-touch entry into using docker for more complex stacks.

--- a/src/articles/job-application-privacy.md
+++ b/src/articles/job-application-privacy.md
@@ -2,7 +2,7 @@
 title: "Today’s job search is a data privacy hellscape"
 description: "Companies are harvesting candidate personal data and there's not much we can do about it."
 permalink: /employer-privacy-job-search/
-og: "job-application-privacy.jpg"
+date: "2024-05-13"
 ---
 
 _TLDR: The lack of widespread data protection laws in the US is putting job-seekers at risk, and the future doesn’t look promising._

--- a/src/pages/404.md
+++ b/src/pages/404.md
@@ -1,0 +1,15 @@
+---
+title: "404"
+permalink: 404.html
+layout: article.njk
+---
+
+The site couldn't find the page you're looking for. Instead, this is the *internet-famous* 404 "Not found" page. 
+
+It's either my fault, the fault of whomever sent you here, or there's some strange internet shenanigans afoot. *Definitely not your fault, as nobody types URLs anymore.*
+
+Perhaps you'll find the something interesting listed in the [Archives](/articles/). Better yet, maybe you're looking to [hire a technical writer](/hire/)?
+
+Anyway, I hope you find what you're looking for. Both here, and in life.
+
+— [Mark](/)

--- a/src/pages/now.md
+++ b/src/pages/now.md
@@ -1,0 +1,25 @@
+---
+title: Now
+permalink: /now/
+layout: article.njk
+---
+
+
+Welcome to `markmichon/now`. Here's what I'm up to lately. This page in inspired by [the /now movement](https://nownownow.com/about). If you see something of interest here, let me know on [Mastodon](https://mastodon.social/@markmichon).
+
+*Last updated: May 14, 2024*
+
+## Work?
+
+I'm actively looking for a new technical writing role! Head over to the [Hire me](/hire/) page for details, or get in touch on [LinkedIn](https://www.linkedin.com/in/markmichon/) or [Mastodon](https://mastodon.social/@markmichon).
+
+## Projects
+
+- This site, the one you're reading, is *finally* seeing some updates. I'm building out new features and writing about them. More to come.
+- Adding features and styling to 👋 *(Wave)*, my bespoke little privacy-first analytics app.
+- Building **Texture**, a site for my writing about travel, cities, and subjects further adrift from code.
+
+## Portland
+
+- After a year in a cool, dark place, last year's batch of [umeshu](https://en.wikipedia.org/wiki/Umeshu) is finally complete.
+- Our kitchen is in peak fermentation mode. Aside from the usual tub of kimchi in the fridge, the pantry has an assortment of in-progress concoctions like [makgeolli](https://en.wikipedia.org/wiki/Makgeolli), mustard, and ginger beer on heavy-rotation.


### PR DESCRIPTION
- Cleans up the frontmater of pages to remove old OG images and include dates where needed.
- Adds 404 page, closes #38 
- Improves the fallback matching for Source Serif Variable fonts.
- Minor adjustments to the 'wa' animation.
- Adds the `/now` page